### PR TITLE
Added ability to create or update users with interests.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -40,8 +40,8 @@ Basic abstraction with Laravel integration for Mailchimp API v3
 // Subscribe a user to your list, existing subscribers will not receive confirmation emails
 Mailchimp::subscribe('listid', 'user@domain.com'); 
 
-// Subscribe a user to your list with merge fields and double-opt-in confirmation disabled
-Mailchimp::subscribe('listid', 'user@domain.com', ['FNAME' => 'First name', 'LNAME' => 'Last name'], false);
+// Subscribe a user to your list with interests (also called groups) and with merge fields and double-opt-in confirmation disabled
+Mailchimp::subscribe('listid', 'user@domain.com', ['460bbbfda1' => true, 'f32e08993d' => false], ['FNAME' => 'First name', 'LNAME' => 'Last name'], false);
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -17,8 +17,9 @@ Basic abstraction with Laravel integration for Mailchimp API v3
 
 - `Mailchimp::check($listId, $emailAddress)` checks to see if an email address is subscribed to a list, returns boolean
 - `Mailchimp::status($listId, $emailAddress)` determines the status of a subscriber, possible responses: 'subscribed', 'unsubscribed', 'cleaned', 'pending', 'transactional' or 'not found'
-- `Mailchimp::subscribe($listId, $emailAddress, $mergeFields = [], $confirm = true)` - adds a new subscriber to the list, or updates an existing subscriber. 
+- `Mailchimp::subscribe($listId, $emailAddress, $mergeFields = [], $interestsFields = [], $confirm = true)` - adds a new subscriber to the list, or updates an existing subscriber. 
     - $mergeFields - optional array of merge fields
+    - $interestsFields - optional array of interests (also called groups) fields
     - $confirm - optional boolean, true = double-opt-in, false = immediately subscribe (permission already obtained)
     - This method ensures that existing subscribers are updated but not asked to reconfirm their subscription.
 - `Mailchimp::getLists()` returns an array of all available lists.
@@ -40,7 +41,7 @@ Basic abstraction with Laravel integration for Mailchimp API v3
 // Subscribe a user to your list, existing subscribers will not receive confirmation emails
 Mailchimp::subscribe('listid', 'user@domain.com'); 
 
-// Subscribe a user to your list with interests (also called groups) and with merge fields and double-opt-in confirmation disabled
+// Subscribe a user to your list with interests and with merge fields and double-opt-in confirmation disabled
 Mailchimp::subscribe('listid', 'user@domain.com', ['460bbbfda1' => true, 'f32e08993d' => false], ['FNAME' => 'First name', 'LNAME' => 'Last name'], false);
 ```
 

--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -55,12 +55,12 @@ class Mailchimp
 
     // Add a member to the list or update an existing member
     // Ensures that existing subscribers are not asked to reconfirm
-    public function subscribe(string $listId, string $email, array $mergeFields = [], bool $confirm = true)
+    public function subscribe(string $listId, string $email, array $mergeFields = [], array $interestsFields = [], bool $confirm = true)
     {
         if ($this->status($listId, $email) == 'subscribed') {
             $confirm = false;
         }
-        $this->api->addUpdateMember($listId, $email, $mergeFields, $confirm);
+        $this->api->addUpdateMember($listId, $email, $mergeFields, $interestsFields, $confirm);
     }
 
     // Make an API call directly

--- a/src/MailchimpApi.php
+++ b/src/MailchimpApi.php
@@ -38,7 +38,7 @@ class MailchimpApi
         return $this->call('get', "/lists/{$listId}/members/{$memberId}");
     }
 
-    public function addUpdateMember(string $listId, string $email, array $merge, bool $confirm)
+    public function addUpdateMember(string $listId, string $email, array $merge, array $interests, bool $confirm)
     {
         $email = strtolower($email);
         $memberId = md5($email);
@@ -51,6 +51,12 @@ class MailchimpApi
         if ($merge) {
             $data['merge_fields'] = $merge;
         }
+
+        // Empty array doesn't work
+        if ($interests) {
+            $data['interests'] = $interests;
+        }
+        
         $this->call('put', "/lists/{$listId}/members/{$memberId}", $data);
     }
 


### PR DESCRIPTION
Hello,
I was using your plugin and trying to add users based on groups and interest (For example, a sport group with soccer and tennis). 
I found out that to subscribe users to these groups a new parameter called interests must be send outside merge list. In this parameter the group ID must be provided with a boolean value that confirm the interest of the user in this group.

I tested this on my app successfully.

Thank you for your attention.
