### PR TITLE
Ability to add tags to list members

### DIFF
--- a/src/Mailchimp.php
+++ b/src/Mailchimp.php
@@ -62,6 +62,12 @@ class Mailchimp
         $this->api->addUpdate($listId, $email, $mergeFields, $confirm);
     }
 
+    // Add tags to member in list
+    public function addTags(string $listId, string $email, array $tags)
+    {
+        $this->api->addTags($listId, $email, $tags);
+    }
+
     public function addUpdateMember(string $listId, Member $member): void
     {
         if ($this->status($listId, $member->parameters()['email_address']) === 'subscribed') {

--- a/src/MailchimpApi.php
+++ b/src/MailchimpApi.php
@@ -51,6 +51,19 @@ class MailchimpApi
         $this->call('put', "/lists/{$listId}/members/{$member->hash()}", $data);
     }
 
+    public function addTags(string $listId, string $email, array $tags)
+    {
+        $email = strtolower($email);
+        $memberId = md5($email);
+        $data = [
+            'tags' => array_map(function($tag) {
+                return ["name" => $tag, "status" => "active"];
+            }, $tags)
+        ];
+
+        $this->call('post', "/lists/{$listId}/members/{$memberId}/tags", $data);
+    }
+
     public function addUpdateMember(string $listId, Member $member): void
     {
         $this->call('put', "/lists/{$listId}/members/{$member->hash()}", $member->parameters());


### PR DESCRIPTION
Adding the ability to more easily add tags to mailing list members in order to facilitate tracking and A/B testing.

For example: `$mc->addTags($listId, $request->email, ["landing_page_2"]);`